### PR TITLE
feat: add face-up card reveal and bottom card selection

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -294,6 +294,25 @@ body {
   position: relative;
 }
 
+.playing-card img {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+}
+
+.faceup-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.faceup-info img {
+  width: 40px;
+  height: 60px;
+  border: 2px solid #333;
+  border-radius: 6px;
+}
+
 .playing-card:hover {
   transform: translateY(-10px) scale(1.05);
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,3 @@
-
 const express = require('express');
 const http = require('http');
 const { Server } = require('socket.io');
@@ -14,16 +13,15 @@ app.get('/', (req, res) => {
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: {
-    origin: '*', // Allow all origins for now
+    origin: '*',
     methods: ['GET', 'POST'],
-    credentials: true
-  }
+    credentials: true,
+  },
 });
-
 
 const PORT = process.env.PORT || 3001;
 
-const ROOM_NAME = "The Pitstop";
+const ROOM_NAME = 'The Pitstop';
 const MAX_PLAYERS = 3;
 
 let gameState = {
@@ -31,15 +29,20 @@ let gameState = {
   playerOrder: [],
   currentTurn: 0,
   deck: [],
-  started: false
+  bottomCards: [],
+  faceUp: null,
+  passes: 0,
+  started: false,
 };
 
 io.on('connection', (socket) => {
   console.log('Player connected:', socket.id);
 
   socket.on('joinGame', (playerName) => {
-    console.log(`${playerName} attempting to join. Current players: ${Object.keys(gameState.players).length}`);
-    
+    console.log(
+      `${playerName} attempting to join. Current players: ${Object.keys(gameState.players).length}`
+    );
+
     if (Object.keys(gameState.players).length >= MAX_PLAYERS) {
       socket.emit('roomFull', { roomName: ROOM_NAME });
       return;
@@ -48,27 +51,20 @@ io.on('connection', (socket) => {
     gameState.players[socket.id] = { name: playerName, hand: [] };
     gameState.playerOrder.push(socket.id);
 
-    console.log('Current game state after join:', {
-      playerCount: Object.keys(gameState.players).length,
-      players: Object.values(gameState.players).map(p => p.name)
-    });
-
     // Send updated player list to all clients
     const playerData = {
-      players: Object.values(gameState.players).map(p => p.name),
-      roomName: ROOM_NAME
+      players: Object.values(gameState.players).map((p) => p.name),
+      roomName: ROOM_NAME,
     };
-    console.log('Broadcasting player list to all clients:', playerData);
     io.emit('playerList', playerData);
 
     // Also send specifically to the joining user after a small delay
     setTimeout(() => {
-      console.log('Sending delayed player list to joining user:', playerData);
       socket.emit('playerList', playerData);
     }, 200);
 
     if (Object.keys(gameState.players).length === MAX_PLAYERS) {
-      startGame();
+      startInitialDeal();
     }
   });
 
@@ -77,23 +73,86 @@ io.on('connection', (socket) => {
     io.emit('gamePaused', gameState.players[socket.id]?.name || 'A player');
   });
 
-  function startGame() {
+  socket.on('bottomDecision', (take) => {
+    if (gameState.playerOrder[gameState.currentChooser] !== socket.id) return;
+
+    if (take) {
+      assignBottomAndStart();
+    } else {
+      gameState.passes += 1;
+      gameState.currentChooser = (gameState.currentChooser + 1) % MAX_PLAYERS;
+      if (gameState.passes === 2) {
+        assignBottomAndStart();
+      } else {
+        promptCurrentChooser();
+      }
+    }
+  });
+
+  function startInitialDeal() {
     gameState.started = true;
     gameState.deck = shuffleDeck();
-    const hands = dealCards(gameState.deck, 3);
+
+    const faceUpIndex = Math.floor(Math.random() * (gameState.deck.length / 2));
+    const faceUpCard = gameState.deck[faceUpIndex];
+    const dealt = gameState.deck.slice(0, 51);
+    gameState.bottomCards = gameState.deck.slice(51);
+    const hands = dealCards(dealt, MAX_PLAYERS);
+
+    const faceUpPlayerIndex = faceUpIndex % MAX_PLAYERS;
+    gameState.faceUp = { card: faceUpCard, playerIndex: faceUpPlayerIndex };
 
     gameState.playerOrder.forEach((id, index) => {
       gameState.players[id].hand = hands[index];
-      io.to(id).emit('startGame', {
-        hand: hands[index],
-        yourTurn: index === 0
+      const previewHand = Array(17).fill('back');
+      if (index === faceUpPlayerIndex) previewHand[0] = faceUpCard;
+      io.to(id).emit('initialDeal', {
+        hand: previewHand,
+        faceUpInfo: {
+          player: gameState.players[gameState.playerOrder[faceUpPlayerIndex]].name,
+          card: faceUpCard,
+        },
       });
     });
 
-    io.emit('gameMessage', `${gameState.players[gameState.playerOrder[0]].name}'s turn`);
+    gameState.currentChooser = faceUpPlayerIndex;
+    gameState.passes = 0;
+    io.emit(
+      'gameMessage',
+      `${gameState.players[gameState.playerOrder[faceUpPlayerIndex]].name} drew ${faceUpCard}`
+    );
+    promptCurrentChooser();
+  }
+
+  function promptCurrentChooser() {
+    const id = gameState.playerOrder[gameState.currentChooser];
+    io.to(id).emit('promptBottom');
+    io.emit('gameMessage', `${gameState.players[id].name}, take the bottom cards?`);
+  }
+
+  function assignBottomAndStart() {
+    const id = gameState.playerOrder[gameState.currentChooser];
+    gameState.players[id].hand.push(...gameState.bottomCards);
+    io.emit('gameMessage', `${gameState.players[id].name} takes the bottom cards.`);
+    startGame(gameState.currentChooser);
+  }
+
+  function startGame(startIndex) {
+    gameState.playerOrder.forEach((id, index) => {
+      io.to(id).emit('startGame', {
+        hand: gameState.players[id].hand,
+        yourTurn: index === startIndex,
+      });
+    });
+
+    io.emit(
+      'gameMessage',
+      `${gameState.players[gameState.playerOrder[startIndex]].name}'s turn`
+    );
   }
 });
 
 server.listen(PORT, '0.0.0.0', () => {
   console.log(`Server running on port ${PORT}`);
 });
+


### PR DESCRIPTION
## Summary
- shuffle and mark a random face-up card in the first half of the deck
- deal 51 face-down cards and prompt players to claim the last three cards
- update client to show card backs, face-up reveal, and landlord decision

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f802921988332bf07e6d92e8ce0a2