### PR TITLE
Allow third player to pass before bottom card reveal

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -258,19 +258,20 @@ body {
   margin-right: 10px;
 }
 
-.you-label {
-  font-size: 0.8rem;
-  color: #ffd700;
-  font-style: italic;
-  margin-right: 10px;
-}
-
 .card-count {
   font-size: 0.8rem;
   color: #fff;
   opacity: 0.8;
   font-weight: bold;
   margin-left: auto;
+}
+
+.points {
+  font-size: 0.8rem;
+  color: #fff;
+  opacity: 0.8;
+  font-weight: bold;
+  margin-left: 10px;
 }
 
 .lobby-info {


### PR DESCRIPTION
## Summary
- let players track initial bidder and whether hands are revealed
- allow all three players to pass once, then reveal hands and restart bidding from the first player
- notify everyone which bottom cards were taken and show full hands to players
- track persistent point totals, award +2/-2 to landlord and +1/-1 to teammates, and display scores in player tiles
- end rounds with a 'Start Next Game' option so players can continue with current scores

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893d34535b88332a6bedd949db10f59