### PR TITLE
Hide facedown bottom cards and highlight landlord

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -253,9 +253,18 @@ body {
   margin-right: 15px;
 }
 
+.player-avatar.landlord {
+  background: linear-gradient(45deg, #ff6b6b, #ee5a52);
+  color: #fff;
+}
+
 .waiting-avatar {
   background: rgba(255, 255, 255, 0.2);
   color: rgba(255, 255, 255, 0.5);
+}
+
+.landlord-text {
+  color: #ee5a52;
 }
 
 .player-name {


### PR DESCRIPTION
## Summary
- avoid revealing bottom cards when picked up while facedown
- color landlord info red and mark landlord avatars with a red gradient
- keep table visible after the round until starting the next game
- restore black joker as the highest card above the red joker
- pause the game on disconnect with a 60s countdown and reset option

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893fa8d105c8332a2f1a02840e10994